### PR TITLE
fix: use --local flag in getPrivkey for per-repo keys

### DIFF
--- a/bin/git-mark.js
+++ b/bin/git-mark.js
@@ -185,7 +185,7 @@ async function broadcastTx(rawHex, explorer) {
 function gitExec(cmd) { return execSync(cmd, { encoding: 'utf8' }).trim(); }
 function getHead() { return gitExec('git rev-parse HEAD'); }
 function getPrivkey() {
-  try { return gitExec('git config nostr.privkey'); } catch { return null; }
+  try { return gitExec('git config --local nostr.privkey'); } catch { return null; }
 }
 function setPrivkey(key) { gitExec(`git config --local nostr.privkey ${key}`); }
 function isGitRoot() { return existsSync('.git'); }


### PR DESCRIPTION
## Summary
- `getPrivkey()` now uses `git config --local` instead of `git config`, ensuring each repo gets its own keypair rather than reusing a global `nostr.privkey`

Closes #16

## Test plan
- [ ] `git mark init` in a fresh repo generates and stores key in `.git/config`
- [ ] Global `nostr.privkey` is not picked up by init