### PR TITLE
feat: add @type Blocktrail to blocktrails.json

### DIFF
--- a/bin/git-mark.js
+++ b/bin/git-mark.js
@@ -249,6 +249,7 @@ async function cmdInit(args) {
 
   // Create trail
   const trail = {
+    '@type': 'Blocktrail',
     version: '0.0.3',
     profile: 'gitmark',
     publicKeyBase: pubkey,


### PR DESCRIPTION
## Summary
- Adds `"@type": "Blocktrail"` to the trail object created by `git mark init`

Closes #24

## Test plan
- [ ] `git mark init` creates blocktrails.json with `@type` field