### PR TITLE
refactor: rename publicKeyBase to pubkeyBase

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The chain of addresses on Bitcoin mirrors the chain of commits in git. Anyone ca
 {
   "version": "0.0.3",
   "profile": "gitmark",
-  "publicKeyBase": "02abc...",
+  "pubkeyBase": "02abc...",
   "chain": "tbtc4",
   "states": ["a1b2c3", "e5f6a7"],
   "txo": [
@@ -70,7 +70,7 @@ The chain of addresses on Bitcoin mirrors the chain of commits in git. Anyone ca
 }
 ```
 
-- **publicKeyBase** — compressed pubkey (02/03 prefix), base for BIP-341 key chaining
+- **pubkeyBase** — compressed pubkey (02/03 prefix), base for BIP-341 key chaining
 - **states** — commit hashes (input to key derivation)
 - **txo** — Bitcoin anchors (TXO URIs, self-contained and verifiable)
 

--- a/bin/git-mark.js
+++ b/bin/git-mark.js
@@ -297,7 +297,7 @@ async function cmdInit(args) {
     '@type': 'Blocktrail',
     version: '0.0.3',
     profile: 'gitmark',
-    publicKeyBase: pubkey,
+    pubkeyBase: pubkey,
     chain,
     states: [],
     txo: []
@@ -376,7 +376,7 @@ async function cmdMark(args) {
     : hexToBytes(privkey);
 
   // Derive next address (chained through all states including current)
-  const nextPub = deriveChainedPubkey(hexToBytes(trail.publicKeyBase), allStates);
+  const nextPub = deriveChainedPubkey(hexToBytes(trail.pubkeyBase), allStates);
   const nextXonly = nextPub.slice(1);
   const nextScript = p2trScript(nextXonly);
 
@@ -411,7 +411,7 @@ async function cmdMark(args) {
     saveTrail(trail);
   }
 
-  const address = pubkeyToAddress(trail.publicKeyBase, allStates, chain);
+  const address = pubkeyToAddress(trail.pubkeyBase, allStates, chain);
   console.log(`Marked: ${head.slice(0, 8)} → ${newTxid.slice(0, 16)}...`);
   console.log(`Address: ${address}`);
   console.log(`Balance: ${outputAmount} sats`);
@@ -426,11 +426,11 @@ async function cmdInfo() {
   console.log(`Profile: ${trail.profile}`);
   console.log(`Version: ${trail.version}`);
   console.log(`Chain: ${trail.chain}`);
-  console.log(`Base public key: ${trail.publicKeyBase}`);
-  console.log(`Base address: ${pubkeyToAddress(trail.publicKeyBase, [], trail.chain)}`);
+  console.log(`Base public key: ${trail.pubkeyBase}`);
+  console.log(`Base address: ${pubkeyToAddress(trail.pubkeyBase, [], trail.chain)}`);
   console.log(`Marks: ${trail.states.length}`);
   if (trail.states.length > 0) {
-    const currentAddr = pubkeyToAddress(trail.publicKeyBase, trail.states, trail.chain);
+    const currentAddr = pubkeyToAddress(trail.pubkeyBase, trail.states, trail.chain);
     console.log(`Current address: ${currentAddr}`);
     console.log(`Last commit: ${trail.states[trail.states.length - 1]}`);
     console.log(`Last TXO: ${trail.txo[trail.txo.length - 1]}`);
@@ -455,7 +455,7 @@ async function cmdVerify() {
 
   for (let i = 0; i < trail.states.length; i++) {
     const statesUpTo = trail.states.slice(0, i + 1);
-    const expectedAddr = pubkeyToAddress(trail.publicKeyBase, statesUpTo, trail.chain);
+    const expectedAddr = pubkeyToAddress(trail.pubkeyBase, statesUpTo, trail.chain);
     const txoUri = trail.txo[i];
     const parsed = parseTxoUri(txoUri);
 

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@ git mark info</pre>
 <pre>{
   "version": "0.0.3",
   "profile": "gitmark",
-  "publicKeyBase": "02abc...",
+  "pubkeyBase": "02abc...",
   "chain": "tbtc4",
   "states": ["a1b2c3...", "e5f6a7..."],
   "txo": [

--- a/test/git-mark.test.js
+++ b/test/git-mark.test.js
@@ -167,7 +167,7 @@ describe('Trail format', () => {
     const trail = {
       version: '0.0.3',
       profile: 'gitmark',
-      publicKeyBase: pubkey,
+      pubkeyBase: pubkey,
       chain: 'tbtc4',
       states: [],
       txo: []
@@ -175,8 +175,8 @@ describe('Trail format', () => {
 
     assert.strictEqual(trail.version, '0.0.3');
     assert.strictEqual(trail.profile, 'gitmark');
-    assert.strictEqual(trail.publicKeyBase.length, 66); // compressed hex
-    assert.ok(trail.publicKeyBase.startsWith('02') || trail.publicKeyBase.startsWith('03'));
+    assert.strictEqual(trail.pubkeyBase.length, 66); // compressed hex
+    assert.ok(trail.pubkeyBase.startsWith('02') || trail.pubkeyBase.startsWith('03'));
     assert.ok(Array.isArray(trail.states));
     assert.ok(Array.isArray(trail.txo));
   });


### PR DESCRIPTION
## Summary
- Rename `publicKeyBase` to `pubkeyBase` across codebase for Nostr naming consistency
- Updated in git-mark.js, tests, README, and index.html

Closes #30

## Test plan
- [ ] `git mark init` creates blocktrails.json with `pubkeyBase`
- [ ] All commands work with the new field name