### PR TITLE
feat: add @id to blocktrails.json

### DIFF
--- a/bin/git-mark.js
+++ b/bin/git-mark.js
@@ -335,6 +335,8 @@ async function cmdInit(args) {
     const newTxid = await broadcastTx(rawTx, explorer);
 
     savePrivateState({ txid: newTxid, vout: 0, amount: outputAmount }, chain);
+    const xonly = pubkey.slice(2); // 64-char x-only Nostr pubkey
+    trail['@id'] = `txo:${chain}:${newTxid}:0?amount=${outputAmount}&pubkey=${xonly}`;
     console.log(`Funded: ${outputAmount} sats (txid: ${newTxid})`);
   }
 

--- a/test/git-mark.test.js
+++ b/test/git-mark.test.js
@@ -189,6 +189,19 @@ describe('Trail format', () => {
     assert.strictEqual(trail.states.length, trail.txo.length);
   });
 
+  it('@id is valid txo URI with amount and 64-char x-only pubkey', () => {
+    const privkey = secp256k1.utils.randomPrivateKey();
+    const pubkey = bytesToHex(secp256k1.getPublicKey(privkey, true));
+    const xonly = pubkey.slice(2);
+    const txid = 'a'.repeat(64);
+    const id = `txo:tbtc4:${txid}:0?amount=14968&pubkey=${xonly}`;
+    const parsed = parseTxoUri(id);
+    assert.strictEqual(parsed.chain, 'tbtc4');
+    assert.strictEqual(parsed.txid, txid);
+    assert.strictEqual(parsed.amount, 14968);
+    assert.strictEqual(xonly.length, 64);
+  });
+
   it('txo URIs include amount and commit params', () => {
     const txoUri = 'txo:tbtc4:abc123:0?amount=9700&commit=deadbeef';
     const parsed = parseTxoUri(txoUri);


### PR DESCRIPTION
## Summary
- Adds `@id` to trail using funding txo URI with amount and 64-char x-only Nostr pubkey
- Set once at init (when funded), never changes
- Enables trail tracking and Nostr identity lookup

Example:
```json
{
  "@type": "Blocktrail",
  "@id": "txo:tbtc4:abc123:0?amount=14968&pubkey=d769d2b8..."
}
```

Closes #32

## Test plan
- [ ] `git mark init --voucher` sets `@id` in blocktrails.json
- [ ] `@id` contains funding txid, amount, and x-only pubkey
- [ ] Unfunded init has no `@id` (set when funded)