### PR TITLE
feat: accept voucher file path in --voucher

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ This gives you `git mark` as a native git subcommand.
 # Initialize in a git repo (tbtc4 = Bitcoin testnet4)
 git mark init --chain tbtc4 --voucher txo:tbtc4:txid:vout?amount=X&key=Y
 
+# Or read vouchers from a file (uses last line, removes on success)
+git mark init --voucher ~/faucet/vouchers.txt
+
 # Make commits, then mark them
 git commit -m "my change"
 git mark

--- a/bin/git-mark.js
+++ b/bin/git-mark.js
@@ -18,6 +18,7 @@ import { execSync } from 'child_process';
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { homedir } from 'os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PKG = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'));
@@ -197,6 +198,23 @@ function getPrivkey() {
 function setPrivkey(key) { gitExec(`git config --local nostr.privkey '${key}'`); }
 function isGitRoot() { return existsSync('.git'); }
 
+function resolveVoucher(arg) {
+  let path = null;
+  if (arg.startsWith('file:')) path = arg.slice(5);
+  else if (arg.endsWith('.txt')) path = arg;
+  if (!path) return { uri: arg, file: null };
+  if (path.startsWith('~')) path = path.replace('~', homedir());
+  const lines = readFileSync(path, 'utf8').split('\n').map(l => l.trim()).filter(Boolean);
+  if (lines.length === 0) { console.error(`No vouchers in ${path}`); process.exit(1); }
+  return { uri: lines[lines.length - 1], file: path };
+}
+
+function consumeVoucher(path) {
+  const lines = readFileSync(path, 'utf8').split('\n').map(l => l.trim()).filter(Boolean);
+  lines.pop();
+  writeFileSync(path, lines.join('\n') + (lines.length ? '\n' : ''));
+}
+
 // --- Trail file helpers ---
 function loadTrail() {
   if (!existsSync(TRAIL_FILE)) return null;
@@ -306,7 +324,8 @@ async function cmdInit(args) {
   // Voucher funding
   const voucherIdx = args.indexOf('--voucher');
   if (voucherIdx !== -1) {
-    const voucherUri = args[voucherIdx + 1];
+    const voucherArg = args[voucherIdx + 1];
+    const { uri: voucherUri, file: voucherFile } = resolveVoucher(voucherArg);
     const txo = parseTxoUri(voucherUri);
     if (!txo.key) { console.error('Voucher must include &key= parameter'); process.exit(1); }
     if (!txo.amount) { console.error('Voucher must include &amount= parameter'); process.exit(1); }
@@ -334,6 +353,7 @@ async function cmdInit(args) {
     );
     const newTxid = await broadcastTx(rawTx, explorer);
 
+    if (voucherFile) consumeVoucher(voucherFile);
     savePrivateState({ txid: newTxid, vout: 0, amount: outputAmount }, chain);
     const xonly = pubkey.slice(2); // 64-char x-only Nostr pubkey
     // Insert @id first
@@ -535,7 +555,8 @@ function cmdUpdate() {
 export {
   taggedHash, btScalar, deriveChainedPrivkey, deriveChainedPubkey,
   pubkeyToAddress, parseTxoUri, p2trScript, buildTransaction,
-  TRAIL_FILE, PRIVATE_FILE, CHAINS, isDirty, loadTrailFromNotes, loadFullTrail
+  TRAIL_FILE, PRIVATE_FILE, CHAINS, isDirty, loadTrailFromNotes, loadFullTrail,
+  resolveVoucher, consumeVoucher
 };
 
 // --- CLI ---

--- a/index.html
+++ b/index.html
@@ -68,6 +68,9 @@
 <pre># Initialize in a git repo
 git mark init --chain tbtc4 --voucher txo:tbtc4:txid:vout?amount=X&amp;key=Y
 
+# Or read vouchers from a file (last line used, removed on success)
+git mark init --voucher ~/faucet/vouchers.txt
+
 # Make commits, then mark them
 git commit -m "my change"
 git mark

--- a/test/git-mark.test.js
+++ b/test/git-mark.test.js
@@ -5,8 +5,12 @@ import { bytesToHex, hexToBytes } from '@noble/hashes/utils';
 
 import {
   taggedHash, btScalar, deriveChainedPrivkey, deriveChainedPubkey,
-  pubkeyToAddress, parseTxoUri, p2trScript, CHAINS, isDirty, loadFullTrail, loadTrailFromNotes
+  pubkeyToAddress, parseTxoUri, p2trScript, CHAINS, isDirty, loadFullTrail, loadTrailFromNotes,
+  resolveVoucher, consumeVoucher
 } from '../bin/git-mark.js';
+import { writeFileSync, readFileSync, unlinkSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 
 describe('Key chaining', () => {
   const privkey = hexToBytes('0000000000000000000000000000000000000000000000000000000000000001');
@@ -252,5 +256,58 @@ describe('TXO URI in git config format', () => {
     assert.strictEqual(parsed.txid, state.txid);
     assert.strictEqual(parsed.vout, state.vout);
     assert.strictEqual(parsed.amount, state.amount);
+  });
+});
+
+describe('Voucher resolution', () => {
+  const uri1 = 'txo:tbtc4:aaa111:0?amount=15568&key=c9cb5a57062b61afc58e5e76d8e587117ba06d2c4e9891ee658896a828e758a6';
+  const uri2 = 'txo:tbtc4:bbb222:1?amount=15568&key=c9cb5a57062b61afc58e5e76d8e587117ba06d2c4e9891ee658896a828e758a6';
+  const uri3 = 'txo:tbtc4:ccc333:2?amount=15568&key=c9cb5a57062b61afc58e5e76d8e587117ba06d2c4e9891ee658896a828e758a6';
+
+  it('returns URI as-is when not a file', () => {
+    const r = resolveVoucher(uri1);
+    assert.strictEqual(r.uri, uri1);
+    assert.strictEqual(r.file, null);
+  });
+
+  it('reads last line from .txt file', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gitmark-test-'));
+    const path = join(dir, 'vouchers.txt');
+    writeFileSync(path, `${uri1}\n${uri2}\n${uri3}\n`);
+    const r = resolveVoucher(path);
+    assert.strictEqual(r.uri, uri3);
+    assert.strictEqual(r.file, path);
+    unlinkSync(path);
+  });
+
+  it('reads last line when using file: prefix', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gitmark-test-'));
+    const path = join(dir, 'vouchers'); // no .txt suffix
+    writeFileSync(path, `${uri1}\n${uri2}\n`);
+    const r = resolveVoucher(`file:${path}`);
+    assert.strictEqual(r.uri, uri2);
+    assert.strictEqual(r.file, path);
+    unlinkSync(path);
+  });
+
+  it('consumeVoucher removes last line', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gitmark-test-'));
+    const path = join(dir, 'vouchers.txt');
+    writeFileSync(path, `${uri1}\n${uri2}\n${uri3}\n`);
+    consumeVoucher(path);
+    const remaining = readFileSync(path, 'utf8').trim().split('\n');
+    assert.strictEqual(remaining.length, 2);
+    assert.strictEqual(remaining[0], uri1);
+    assert.strictEqual(remaining[1], uri2);
+    unlinkSync(path);
+  });
+
+  it('consumeVoucher handles last remaining line', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gitmark-test-'));
+    const path = join(dir, 'vouchers.txt');
+    writeFileSync(path, `${uri1}\n`);
+    consumeVoucher(path);
+    assert.strictEqual(readFileSync(path, 'utf8'), '');
+    unlinkSync(path);
   });
 });

--- a/test/git-mark.test.js
+++ b/test/git-mark.test.js
@@ -8,9 +8,9 @@ import {
   pubkeyToAddress, parseTxoUri, p2trScript, CHAINS, isDirty, loadFullTrail, loadTrailFromNotes,
   resolveVoucher, consumeVoucher
 } from '../bin/git-mark.js';
-import { writeFileSync, readFileSync, mkdtempSync, rmSync, mkdirSync } from 'fs';
+import { writeFileSync, readFileSync, mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
-import { tmpdir, homedir } from 'os';
+import { tmpdir } from 'os';
 
 describe('Key chaining', () => {
   const privkey = hexToBytes('0000000000000000000000000000000000000000000000000000000000000001');
@@ -297,18 +297,18 @@ describe('Voucher resolution', () => {
   });
 
   it('expands ~ to home directory', () => {
-    const home = homedir();
-    const testDir = join(home, '.gitmark-test-tmp');
-    mkdirSync(testDir, { recursive: true });
+    const fakeHome = mkdtempSync(join(tmpdir(), 'gitmark-home-'));
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
     try {
-      const path = join(testDir, 'vouchers.txt');
+      const path = join(fakeHome, 'vouchers.txt');
       writeFileSync(path, `${uri1}\n`);
-      const relativePath = '~' + path.slice(home.length);
-      const r = resolveVoucher(relativePath);
+      const r = resolveVoucher('~/vouchers.txt');
       assert.strictEqual(r.uri, uri1);
       assert.strictEqual(r.file, path);
     } finally {
-      rmSync(testDir, { recursive: true, force: true });
+      process.env.HOME = originalHome;
+      rmSync(fakeHome, { recursive: true, force: true });
     }
   });
 

--- a/test/git-mark.test.js
+++ b/test/git-mark.test.js
@@ -8,9 +8,9 @@ import {
   pubkeyToAddress, parseTxoUri, p2trScript, CHAINS, isDirty, loadFullTrail, loadTrailFromNotes,
   resolveVoucher, consumeVoucher
 } from '../bin/git-mark.js';
-import { writeFileSync, readFileSync, unlinkSync, mkdtempSync } from 'fs';
+import { writeFileSync, readFileSync, mkdtempSync, rmSync, mkdirSync } from 'fs';
 import { join } from 'path';
-import { tmpdir } from 'os';
+import { tmpdir, homedir } from 'os';
 
 describe('Key chaining', () => {
   const privkey = hexToBytes('0000000000000000000000000000000000000000000000000000000000000001');
@@ -272,42 +272,91 @@ describe('Voucher resolution', () => {
 
   it('reads last line from .txt file', () => {
     const dir = mkdtempSync(join(tmpdir(), 'gitmark-test-'));
-    const path = join(dir, 'vouchers.txt');
-    writeFileSync(path, `${uri1}\n${uri2}\n${uri3}\n`);
-    const r = resolveVoucher(path);
-    assert.strictEqual(r.uri, uri3);
-    assert.strictEqual(r.file, path);
-    unlinkSync(path);
+    try {
+      const path = join(dir, 'vouchers.txt');
+      writeFileSync(path, `${uri1}\n${uri2}\n${uri3}\n`);
+      const r = resolveVoucher(path);
+      assert.strictEqual(r.uri, uri3);
+      assert.strictEqual(r.file, path);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('reads last line when using file: prefix', () => {
     const dir = mkdtempSync(join(tmpdir(), 'gitmark-test-'));
-    const path = join(dir, 'vouchers'); // no .txt suffix
-    writeFileSync(path, `${uri1}\n${uri2}\n`);
-    const r = resolveVoucher(`file:${path}`);
-    assert.strictEqual(r.uri, uri2);
-    assert.strictEqual(r.file, path);
-    unlinkSync(path);
+    try {
+      const path = join(dir, 'vouchers'); // no .txt suffix
+      writeFileSync(path, `${uri1}\n${uri2}\n`);
+      const r = resolveVoucher(`file:${path}`);
+      assert.strictEqual(r.uri, uri2);
+      assert.strictEqual(r.file, path);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('expands ~ to home directory', () => {
+    const home = homedir();
+    const testDir = join(home, '.gitmark-test-tmp');
+    mkdirSync(testDir, { recursive: true });
+    try {
+      const path = join(testDir, 'vouchers.txt');
+      writeFileSync(path, `${uri1}\n`);
+      const relativePath = '~' + path.slice(home.length);
+      const r = resolveVoucher(relativePath);
+      assert.strictEqual(r.uri, uri1);
+      assert.strictEqual(r.file, path);
+    } finally {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('exits with error on empty file', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gitmark-test-'));
+    const originalExit = process.exit;
+    const originalError = console.error;
+    let exitCode = null;
+    let errorMsg = null;
+    process.exit = (code) => { exitCode = code; throw new Error('exit called'); };
+    console.error = (msg) => { errorMsg = msg; };
+    try {
+      const path = join(dir, 'empty.txt');
+      writeFileSync(path, '');
+      assert.throws(() => resolveVoucher(path), /exit called/);
+      assert.strictEqual(exitCode, 1);
+      assert.match(errorMsg, /No vouchers/);
+    } finally {
+      process.exit = originalExit;
+      console.error = originalError;
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('consumeVoucher removes last line', () => {
     const dir = mkdtempSync(join(tmpdir(), 'gitmark-test-'));
-    const path = join(dir, 'vouchers.txt');
-    writeFileSync(path, `${uri1}\n${uri2}\n${uri3}\n`);
-    consumeVoucher(path);
-    const remaining = readFileSync(path, 'utf8').trim().split('\n');
-    assert.strictEqual(remaining.length, 2);
-    assert.strictEqual(remaining[0], uri1);
-    assert.strictEqual(remaining[1], uri2);
-    unlinkSync(path);
+    try {
+      const path = join(dir, 'vouchers.txt');
+      writeFileSync(path, `${uri1}\n${uri2}\n${uri3}\n`);
+      consumeVoucher(path);
+      const remaining = readFileSync(path, 'utf8').trim().split('\n');
+      assert.strictEqual(remaining.length, 2);
+      assert.strictEqual(remaining[0], uri1);
+      assert.strictEqual(remaining[1], uri2);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('consumeVoucher handles last remaining line', () => {
     const dir = mkdtempSync(join(tmpdir(), 'gitmark-test-'));
-    const path = join(dir, 'vouchers.txt');
-    writeFileSync(path, `${uri1}\n`);
-    consumeVoucher(path);
-    assert.strictEqual(readFileSync(path, 'utf8'), '');
-    unlinkSync(path);
+    try {
+      const path = join(dir, 'vouchers.txt');
+      writeFileSync(path, `${uri1}\n`);
+      consumeVoucher(path);
+      assert.strictEqual(readFileSync(path, 'utf8'), '');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary
- `--voucher` now accepts either a txo URI (current), a path ending in `.txt`, or a path with `file:` prefix
- File mode: reads the last line as the voucher URI, removes it on successful broadcast
- Supports `~` expansion for home directory
- Enables voucher queue management from files like `~/faucet/vouchers.txt`

Closes #40

## Test plan
- [ ] `git mark init --voucher ~/faucet/vouchers.txt` uses last line, removes on success
- [ ] `git mark init --voucher file:~/vouchers` works without `.txt` suffix
- [ ] `git mark init --voucher txo:...` still works (plain URI)
- [ ] Empty file gives clear error